### PR TITLE
fix: adjusted position of student profile view to the top of the page

### DIFF
--- a/attendance-tracking-tool-app/src/components/StudentProfileButton.js
+++ b/attendance-tracking-tool-app/src/components/StudentProfileButton.js
@@ -15,10 +15,10 @@ function StudentProfileButton() {
         cursor: 'pointer',
         marginTop: '10px',
         marginBottom: '20px',
-        marginLeft: '20px',
+        marginLeft: '100px',
         position: 'absolute',   // Set position
-        bottom: '80px',         // Position at the bottom
-        left: '45%',
+        top: '100px',         // Position the button at the top of the page
+        left: '25%',
         
     };
   


### PR DESCRIPTION
In the meeting on Thursday, 04/25, Tabia asked to move the button to "View student profiles" to the top of the page next ti the upload CSV button for better User Experience.